### PR TITLE
Don't default to site email when sending digests (empty emails case)

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -306,8 +306,8 @@ function digest_send_mail(ElggUser $user, $subject, $html_body, $plain_link = ""
 			$html_body = $transform;
 		}
 		
-		// email settings
-		$to = html_email_handler_make_rfc822_address($user);
+		// email settings - prevent sending to any other address than the recipient personn
+		$to = html_email_handler_make_rfc822_address($user, false);
 		
 		$plaintext_message = "";
 		if (!empty($plain_link)) {


### PR DESCRIPTION
This small patch addresses issue https://github.com/ColdTrick/digest/issues/12#issuecomment-50476020
