### PR TITLE
Patch for fatal getGUID() error

### DIFF
--- a/views/default/digest/elements/unsubscribe.php
+++ b/views/default/digest/elements/unsubscribe.php
@@ -20,7 +20,7 @@ $user = elgg_extract("user", $vars);
 $site = elgg_get_site_entity();
 $digest_entity = elgg_extract("group", $vars, $site);
 if (!elgg_instanceof($digest_entity, 'group')) {
-  $digest_entity = $site;
+	$digest_entity = $site;
 }
 
 $unsubscribe_link = digest_create_unsubscribe_link($digest_entity->getGUID(), $user);


### PR DESCRIPTION
This patch is described in https://github.com/ColdTrick/digest/issues/18 and corrects a PHP error.
